### PR TITLE
Adding docker-compose based approach for launching a cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 Run Ambari within Docker containers!
 
 # Building and starting the cluster
-The database container must be started before running the build script, otherwise ambari-setup will fail when attempting to validate the connection to the database container.
+
+## Using docker-compose
+
+Follow the steps from the [docker-compose/README.md](./docker-compose/README.md) file.
+
+## Using docker and shell scripts
 
 ## The run.sh script
     usage: docker/scripts/run.sh -d -c [-n #] [-h]
@@ -12,9 +17,12 @@ The database container must be started before running the build script, otherwis
            -n or --agent-node-count        specifies the number of ambari-agent containers
 
 ### From the scripts directory:
+
 1. ./run.sh -d
 1. ./build.sh
 1. ./run.sh -c [-n *n*]
+
+Note: The database container must be started before running the build script, otherwise ambari-setup will fail when attempting to validate the connection to the database container.
 
 # Containers started by the run.sh script
 Several containers are started by the run.sh script:

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,101 @@
+# Containerized Ambari: Docker Compose
+
+An alternative to using the `build.sh` and `run.sh` scripts in the `docker/` directory is to launch and manage environments using `docker-compose`. The docker-compose tool will use the included [docker-compose.yml](./docker-compose.yml) configuration to build images, create (and scale) containers, etc.
+
+# Quick Start with docker-compose
+
+From the docker-compose directory in the repository, you can use the following commands:
+
+    # create and start a new Ambari cluster with N agent nodes, detached 
+    docker-compose up -d --scale ambari-agent=N
+    
+    # view the logs
+    docker-compose logs -f
+    
+    # stop the cluster
+    docker-compose stop
+    
+    # start the cluster (note, it is recommended to enable auto service start for all Ambari services)
+    docker-compose start
+    
+    # add an agent node to the cluster (not sure if this is recommended after installing Ambari services)
+    docker-compose up -d --scale ambari-agent=N+1
+    
+    # rebuild one of the locally-built images (should not need to do this outside of developement)
+    docker-compose build <service-name>
+    # e.g.
+    docker-compose build ambari-server
+    
+    # destroy the cluster (actaully removes the containers, data, and configuration so be careful!)
+    docker-compose down
+
+If running docker-compose from another directory, you can use the `-f` option to sepcify the location of the docker-compose.yml file. For example:
+
+    docker-compose -f /path/to/docker-compose.yml up -d --scale ambari-agent=N
+   
+To generate a dynmaic docker-compose, use the `-f` flag with `-` as the value to stpecify reading from STDIN. For example:
+
+    my-command-that-writes-YAML-to-STDOUT | docker-compose -f - up -d --scale ambari-agent=N
+
+Note that the -f argument must come before the docker-compose subcommand (`up` in the above example) and included every time you invoke `docker-compose` command to manage your containerized ambari environmnet.
+
+
+# Configuring docker-compose.yml
+
+The repositoriy includes an example [docker-compose.yml](./docker-compose.yml) that you can use directly (see quick start above). It includes the following containerized services:
+
+## Reverse Proxy (Traefik)
+
+A [Traefik](https://github.com/containous/traefik) proxy that exposes other services to the host machine, such as the Ambari UI.
+
+When the service is running, you can access its dashboard web UI in Chrome at http://localhost:8080
+
+## Ambari Server
+
+Manages the Ambari cluster on the various Ambari Agent containers. When the service is running and the Traefik Reverse Proxy is running, the Ambari Server Web UI is accessible at http://ambari-server.docker.localhost
+
+The docker image for the Ambari Server service is built from the local [Dockerfile](../docker/ambari-server) the first time that `docker-compose up` is run. This can take a long time and configures the local server as well as the database (postgres, see below). After the initial container is built, it is tagged and will not need to be re-built unless `docker-compose down` or `docker-compose build` is run.
+
+If you have built the Ambari Server image already and want to use that image instead of building it from the Dockerfile, simply make the following change `ambari-server` service definition:
+
+    ambari-server:
+      build:
+        context: ../docker/ambari-server
+      ### Remove the build settings above, specify your pre-built image name below ###
+      image: ambari-server-ubuntu
+      ...
+
+The following configuration options for the Ambari Server are controlled by the container's evironment:
+
+| Environment Variable | Default | Description |
+| --- | --- | --- |
+| `AMBARI_OS_USER` | root | The OS user to use to setup Ambari on first run |
+| `AMBARI_DB_HOST` | postgres | The hostname of the Postgres DB service | 
+| `AMBARI_DB_USER` | ambari | The database user Ambari will create and use to access the DB |
+| `AMBARI_DB_PASSWORD` | bigdata | The password for the Ambari database user |
+| `AMBARI_DB_NAME` | ambari | The name of the database that Ambari will create for itself |
+| `AMBARI_DB_SCHEMA` | ambari | The name of the database schema that Ambari will create for itself  |
+
+Note that if you change the service name or alias of the Postgres database in the docker-compose.yml file, then the value of `AMBARI_DB_HOST` should be updated to reflect a hostname that will be accessible to the Ambari Server service.
+
+## Ambari Agent
+
+This service should be scaled to the number of Ambari cluster nodes you wish to have available. For example, if you wish to have three Ambari agents to target for your HDP or HDF cluster, you would first create the docker-compose environment using the scale option:
+
+    docker-compose up -d --scale ambari-agent=3
+    
+This will create three ambari-agent containers, and each one will start an agent process that registers itself with the Ambari Server (note, this is done eagerly with retry, so if the agent containers start before the Ambari Server process is done loading, you can ignore any "connection failed" log messages from the Agent).
+
+The following configuration options for the Ambari Agent are controlled by the container's evironment:
+
+| Envrionment Variable | Default | Description |
+| --- | --- | --- |
+| `AMBARI_SERVER_HOSTNAME` | ambari-server | The hostname of the Ambari Server service |
+
+Note that if you change the service name or alias of the Ambari Server in the docker-compose.yml file, then the value of `AMBARI_SERVER_HOSTNAME` should be updated to reflect a hostname that will be accessible to the Ambari Agent containers.
+
+## Postgres
+
+A database from on the official Postgres 9.6 dockerhub image. Ambari Server will initialize the user and schema on first startup.
+
+

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3'
+
+networks:
+  ambari-bridge:
+
+services:
+  reverse-proxy:
+    image: traefik # The official Traefik docker image
+    command: --api --docker # Enables the web UI and tells Traefik to listen to docker
+    ports:
+      - 80:80     # The HTTP port
+      - 8080:8080 # The Web UI (enabled by --api)
+    networks:
+      - ambari-bridge
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
+
+  postgres:
+    image: postgres:9.6.8
+    ports:
+      - 5432
+    networks:
+      - ambari-bridge
+
+  ambari-server:
+    build:
+      context: ../docker/ambari-server
+    image: ambari-server-ubuntu  # tags the built image
+    environment:
+      AMBARI_OS_USER: root
+      AMBARI_DB_USER: ambari
+      AMBARI_DB_NAME: ambari
+      AMBARI_DB_SCHEMA: ambari
+      AMBARI_DB_PASSWORD: bigdata
+      AMBARI_DB_HOST: postgres
+    networks:
+      - ambari-bridge
+    labels:
+      traefik.frontend.rule: "Host:ambari-server.docker.localhost"
+    depends_on:
+      - postgres
+
+  ambari-agent:
+    build:
+      context: ../docker/ambari-agent
+    image: ambari-agent-ubuntu  # tags the built image
+    environment:
+      AMBARI_SERVER_HOSTNAME: ambari-server
+    networks:
+      - ambari-bridge
+    depends_on:
+      - ambari-server

--- a/docker/ambari-agent/Dockerfile
+++ b/docker/ambari-agent/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:16.04
 
 ARG ambari_repo=http://public-repo-1.hortonworks.com/ambari/ubuntu16/2.x/updates/2.7.1.0/ambari.list
-ARG ambari_os_user=root
-ARG ambari_server_hostname=ambari-server-ubuntu
+ARG default_ambari_server_hostname=ambari-server
 
 # add ambari ubuntu repository
 RUN apt-get update
@@ -13,9 +12,10 @@ RUN apt-get update
 
 RUN apt-get install -y ambari-agent
 
-RUN sed -i "s/^hostname=.*/hostname=$ambari_server_hostname/g" /etc/ambari-agent/conf/ambari-agent.ini
-
 ADD scripts/start.sh /root/start.sh
 RUN chmod +x /root/start.sh
+
+# this sets the default hostname. at runtime, it can be overwritten with the AMBARI_SERVER_HOSTNAME env var
+RUN sed -i "s/^hostname=.*/hostname=$default_ambari_server_hostname/g" /etc/ambari-agent/conf/ambari-agent.ini
 
 ENTRYPOINT  ["/root/start.sh"]

--- a/docker/ambari-agent/scripts/start.sh
+++ b/docker/ambari-agent/scripts/start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+[[ -z $AMBARI_SERVER_HOSTNAME ]] && sed -i "s/^hostname=.*/hostname=$AMBARI_SERVER_HOSTNAME/g" /etc/ambari-agent/conf/ambari-agent.ini
+
 ambari-agent start
 
 tail -f /var/log/ambari-agent/ambari-agent.log

--- a/docker/ambari-server/Dockerfile
+++ b/docker/ambari-server/Dockerfile
@@ -2,14 +2,12 @@ FROM ubuntu:16.04
 
 ARG ambari_repo=http://public-repo-1.hortonworks.com/ambari/ubuntu16/2.x/updates/2.7.1.0/ambari.list
 ARG hdp_utils_repo=http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-ARG ambari_os_user=root
-ARG ambari_db_name=ambari
-ARG ambari_db_user=ambari
-ARG ambari_db_schema=ambari
-ARG ambari_db_password=bigdata
-ARG database_hostname
-
-RUN if [ -z "$database_hostname" ]; then echo "Expected a database hostname"; exit 1; fi
+ARG default_ambari_os_user=root
+ARG default_ambari_db_name=ambari
+ARG default_ambari_db_user=ambari
+ARG default_ambari_db_schema=ambari
+ARG default_ambari_db_password=bigdata
+ARG default_database_hostname=postgres
 
 VOLUME /resources
 
@@ -33,8 +31,7 @@ RUN chmod +x /root/database-setup.sh
 ADD scripts/start.sh /root/start.sh
 RUN chmod +x /root/start.sh
 
-RUN /root/ambari-setup.sh --os-user $ambari_os_user --ambari-db-user $ambari_db_user --ambari-db-name $ambari_db_name --ambari-db-schema $ambari_db_schema --ambari-db-password $ambari_db_password --database-hostname $database_hostname
-RUN /root/database-setup.sh --ambari-db-user $ambari_db_user --ambari-db-name $ambari_db_name --ambari-db-schema $ambari_db_schema --ambari-db-password $ambari_db_password --database-hostname $database_hostname
+# TODO, write default values somewhere where they can be read by the start script when running a container
 
 EXPOSE 8080
 ENTRYPOINT  ["/root/start.sh"]

--- a/docker/ambari-server/scripts/start.sh
+++ b/docker/ambari-server/scripts/start.sh
@@ -1,11 +1,53 @@
 #!/usr/bin/env bash
 
+#
+# This bash script will initialize/setup Ambari and the external postgres database on first run,
+# and then start Amabari. After the first successful start, setup will not happen again.
+#
+# The following environment variables are recognized:
+#    AMBARI_OS_USER     The OS user to use to setup Ambari on first run. Default 'root'
+#    AMBARI_DB_HOST     The hostname of the external Postgres DB to use for Ambari. Default 'postgres'
+#    AMBARI_DB_USER     The database user Ambari will create and use to access the DB. Default 'ambari'
+#    AMBARI_DB_PASSWORD The password for the Ambari database user. Default 'bigdata'
+#    AMBARI_DB_NAME     The name of the database that Ambari will create for itself. Default 'ambari'
+#    AMBARI_DB_SCHEMA   The name of the database schema that Ambari will create for itself. Default 'ambari'
+#    DEBUG              Set to any non-zero length value to enable debug output for this script. Unset to disable.
+#
+
+# Enable DEBUG output if enabled
+[ -n "$DEBUG" ] && set -x
+
+[[ -z $AMBARI_OS_USER ]] && AMBARI_OS_USER=root
+[[ -z $AMBARI_DB_USER ]] && AMBARI_DB_USER=ambari
+[[ -z $AMBARI_DB_NAME ]] && AMBARI_DB_NAME=ambari
+[[ -z $AMBARI_DB_SCHEMA ]] && AMBARI_DB_SCHEMA=ambari
+[[ -z $AMBARI_DB_PASSWORD ]] && AMBARI_DB_PASSWORD=bigdata
+[[ -z $AMBARI_DB_HOST ]] && AMBARI_DB_HOST=postgres  # expected to be running in another container on the same docker network
+
 startedFile="/root/container-was-started"
 if [ ! -e "$startedFile" ] ; then
   # container hasn't been started yet, additional setup steps should run
-  :
+
+  sleep 5  # wait for the database on an external host to startup in case these containers were launched together
+  
+  /root/database-setup.sh \
+    --ambari-db-user $AMBARI_DB_USER \
+    --ambari-db-name $AMBARI_DB_NAME \
+    --ambari-db-schema $AMBARI_DB_SCHEMA \
+    --ambari-db-password $AMBARI_DB_PASSWORD \
+    --database-hostname $AMBARI_DB_HOST
+
+  /root/ambari-setup.sh \
+    --os-user $AMBARI_OS_USER \
+    --ambari-db-user $AMBARI_DB_USER \
+    --ambari-db-name $AMBARI_DB_NAME \
+    --ambari-db-schema $AMBARI_DB_SCHEMA \
+    --ambari-db-password $AMBARI_DB_PASSWORD \
+    --database-hostname $AMBARI_DB_HOST
 fi
+
 ambari-server start
+
 if [ ! -e "$startedFile" ] ; then
   # ambari successfully started, create startedFile to prevent ambari db setup steps above from running
   touch $startedFile


### PR DESCRIPTION
@jtstorck take a look at this. A little more cleanup work is needed to make things consistent between the docker-compose environment and the script-based docker environment. For example. docker-compose makes ambari accesible at http://ambari-server.docker.localhost (the default traefik subdomain) rather than a custom hostname / base domain. That should be easy to align, but everything else is working so far so wanted to make this available for you to play with and provide input on.